### PR TITLE
Remove #defines reserved by the C standard

### DIFF
--- a/SampleCode/Switchless/App/App.cpp
+++ b/SampleCode/Switchless/App/App.cpp
@@ -199,7 +199,7 @@ int initialize_enclave(const sgx_uswitchless_config_t* us_config)
     /* Step 2: call sgx_create_enclave to initialize an enclave instance */
     /* Debug Support: set 2nd parameter to 1 */
 
-    void* enclave_ex_p[32] = { 0 };
+    const void* enclave_ex_p[32] = { 0 };
 
     enclave_ex_p[SGX_CREATE_ENCLAVE_EX_SWITCHLESS_BIT_IDX] = (void*)us_config;
 

--- a/common/inc/sgx_urts.h
+++ b/common/inc/sgx_urts.h
@@ -82,7 +82,7 @@ sgx_status_t SGXAPI sgx_create_enclave_ex(const char * file_name,
                                           sgx_enclave_id_t * enclave_id, 
                                           sgx_misc_attribute_t * misc_attr,  
                                           const uint32_t ex_features, 
-                                          void* ex_features_p[32]);
+                                          const void* ex_features_p[32]);
 
 
 sgx_status_t SGXAPI sgx_create_encrypted_enclave(

--- a/external/epid-sdk/ext/ipp/include/ippbase.h
+++ b/external/epid-sdk/ext/ipp/include/ippbase.h
@@ -36,16 +36,14 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+
 #if defined( _WIN32 ) || defined ( _WIN64 )
   #define __STDCALL  __stdcall
   #define __CDECL    __cdecl
-  #define __INT64    __int64
-  #define __UINT64    unsigned __int64
 #else
   #define __STDCALL
   #define __CDECL
-  #define __INT64    long long
-  #define __UINT64    unsigned long long
 #endif
 
 #define IPP_PI    ( 3.14159265358979323846 )  /* ANSI C does not support M_PI */
@@ -117,8 +115,8 @@ typedef signed char    Ipp8s;
 typedef signed short   Ipp16s;
 typedef signed int     Ipp32s;
 typedef float          Ipp32f;
-typedef __INT64        Ipp64s;
-typedef __UINT64       Ipp64u;
+typedef int64_t        Ipp64s;
+typedef uint64_t       Ipp64u;
 typedef double         Ipp64f;
 typedef Ipp16s         Ipp16f;
 

--- a/psw/urts/linux/urts.cpp
+++ b/psw/urts/linux/urts.cpp
@@ -40,7 +40,7 @@
 
 #include "urts_com.h"
 
-static bool inline _check_ex_params_(const uint32_t ex_features, void* ex_features_p[32])
+static bool inline _check_ex_params_(const uint32_t ex_features, const void* ex_features_p[32])
 {
     //update last feature index if it fails here
     se_static_assert(_SGX_LAST_EX_FEATURE_IDX_ == SGX_CREATE_ENCLAVE_EX_SWITCHLESS_BIT_IDX);
@@ -64,7 +64,7 @@ extern "C" sgx_status_t __sgx_create_enclave_ex(const char *file_name,
                                                 sgx_enclave_id_t *enclave_id, 
                                                 sgx_misc_attribute_t *misc_attr,
                                                 const uint32_t ex_features,
-                                                void* ex_features_p[32])
+                                                const void* ex_features_p[32])
 {
     sgx_status_t ret = SGX_SUCCESS;
 
@@ -120,7 +120,7 @@ extern "C"  sgx_status_t sgx_create_enclave_ex(const char *file_name,
                                                sgx_enclave_id_t *enclave_id,
                                                sgx_misc_attribute_t *misc_attr,
                                                const uint32_t ex_features,
-                                               void* ex_features_p[32])
+                                               const void* ex_features_p[32])
 {
 
     return __sgx_create_enclave_ex(file_name, debug, launch_token,
@@ -139,7 +139,7 @@ sgx_create_encrypted_enclave(
     uint8_t* sealed_key)
 {
     uint32_t ex_features = SGX_CREATE_ENCLAVE_EX_PCL;
-    void* ex_features_p[32] = { 0 };
+    const void* ex_features_p[32] = { 0 };
     ex_features_p[SGX_CREATE_ENCLAVE_EX_PCL_BIT_IDX] = (void*)sealed_key;
 
     return __sgx_create_enclave_ex(file_name, debug, launch_token,

--- a/psw/urts/urts_com.h
+++ b/psw/urts/urts_com.h
@@ -193,7 +193,7 @@ static int __create_enclave(BinParser &parser,
                             sgx_enclave_id_t *enclave_id, 
                             sgx_misc_attribute_t *misc_attr,
                             const uint32_t ex_features,
-                            void* ex_features_p[32])
+                            const void* ex_features_p[32])
 {
     // The "parser" will be registered into "loader" and "loader" will be registered into "enclave".
     // After enclave is created, "parser" and "loader" are not needed any more.
@@ -425,7 +425,7 @@ fail:
 
 sgx_status_t _create_enclave_ex(const bool debug, se_file_handle_t pfile, se_file_t& file, le_prd_css_file_t *prd_css_file, 
 	                            sgx_launch_token_t *launch, int *launch_updated, sgx_enclave_id_t *enclave_id, 
-                                sgx_misc_attribute_t *misc_attr, const uint32_t ex_features, void* ex_features_p[32])
+                                sgx_misc_attribute_t *misc_attr, const uint32_t ex_features, const void* ex_features_p[32])
 {
     unsigned int ret = SGX_SUCCESS;
     sgx_status_t lt_result = SGX_SUCCESS;

--- a/sdk/edger8r/linux/Ast.ml
+++ b/sdk/edger8r/linux/Ast.ml
@@ -191,6 +191,26 @@ type enclave = {
   eexpr : expr list;        (* expressions inside enclave. *)
 }
 
+(*
+  Plugin.ml operates on an enclave_content instance.
+  CodeGen.ml calls Plugin.ml if a plugin is installed and hence
+  depends on Plugin.ml.
+  To prevent cyclic dependency between Plugin.ml and Codegen.ml,
+  enclave_content is defined here. Additionally, the enclave_content 
+  type in CodeGen.ml is defined to be equivalent to the enclave_content 
+  type defined here.
+*)
+type enclave_content = {
+  file_shortnm : string; (* the short name of original EDL file *)
+  enclave_name : string; (* the normalized C identifier *)
+
+  include_list : string list;
+  import_exprs : import_decl list;
+  comp_defs    : composite_type list;
+  tfunc_decls  : trusted_func   list;
+  ufunc_decls  : untrusted_func list;
+}
+
 (* -------------------------------------------------------------------
  *  Some utility function to manupulate types defined in AST.
  * -------------------------------------------------------------------

--- a/sdk/edger8r/linux/CodeGen.ml
+++ b/sdk/edger8r/linux/CodeGen.ml
@@ -39,7 +39,7 @@ open Util                               (* for failwithf *)
  *)
 
 (* This record type is used to better organize a value of Ast.enclave *)
-type enclave_content = {
+type enclave_content = Ast.enclave_content = {
   file_shortnm : string; (* the short name of original EDL file *)
   enclave_name : string; (* the normalized C identifier *)
 
@@ -1714,5 +1714,9 @@ let gen_enclave_code (e: Ast.enclave) (ep: edger8r_params) =
     check_duplication ec;
     check_allow_list ec;
     (if not ep.header_only then check_priv_funcs ec);
-    (if ep.gen_untrusted then (gen_untrusted_header ec; if not ep.header_only then gen_untrusted_source ec));
-    (if ep.gen_trusted then (gen_trusted_header ec; if not ep.header_only then gen_trusted_source ec))
+    if Plugin.available() then
+      Plugin.gen_edge_routines ec ep
+    else (
+      (if ep.gen_untrusted then (gen_untrusted_header ec; if not ep.header_only then gen_untrusted_source ec));
+      (if ep.gen_trusted then (gen_trusted_header ec; if not ep.header_only then gen_trusted_source ec))
+    )

--- a/sdk/edger8r/linux/Plugin.ml
+++ b/sdk/edger8r/linux/Plugin.ml
@@ -1,0 +1,22 @@
+(* 
+    Dependency injection plugin to allow custom code generation
+    from EDL. CodeGen.ml calls into Plugin.available to check 
+    if a plugin available. If a plugin is available, then it calls 
+    Plugin.gen_edge_routines to generate custom code. 
+    Otherwise, it generates code for Intel(R) SGX  SDK.
+*)
+
+type plugin = {
+    mutable available: bool;
+    mutable gen_edge_routines:
+         Ast.enclave_content -> Util.edger8r_params -> unit;
+}
+
+(* Instance fields will be populated by Open Enclave *)
+let instance = {
+    available = false;
+    gen_edge_routines = fun ec ep -> Printf.printf "Plugin not loaded.\n"
+}
+
+let available () = instance.available
+let gen_edge_routines ec ep = instance.gen_edge_routines ec ep

--- a/sdk/sign_tool/SignTool/elf_helper.h
+++ b/sdk/sign_tool/SignTool/elf_helper.h
@@ -44,7 +44,7 @@ static void dump_textrel(const uint64_t& offset)
     using namespace std;
 
     cerr << "warning: TEXTRELs found at offset: "
-         << hex << showbase     /* show the '0x' prefix */
+         << std::hex << showbase     /* show the '0x' prefix */
          << offset << endl;
 }
 

--- a/sdk/sign_tool/SignTool/manage_metadata.cpp
+++ b/sdk/sign_tool/SignTool/manage_metadata.cpp
@@ -229,7 +229,7 @@ bool CMetadata::get_time(uint32_t *date)
     uint32_t tmp_date = (timeinfo->tm_year+1900)*10000 + (timeinfo->tm_mon+1)*100 + timeinfo->tm_mday;
     stringstream ss;
     ss<<"0x"<<tmp_date;
-    ss>>hex>>tmp_date;
+    ss>>std::hex>>tmp_date;
     *date = tmp_date;
     return true;
 }

--- a/sdk/simulation/assembly/lowlib.h
+++ b/sdk/simulation/assembly/lowlib.h
@@ -40,6 +40,15 @@
 
 #include <stdint.h>
 
+#if defined(__GNUC__) && !defined(__clang__)
+#define LOAD_REGS_ATTRIBUTES \
+  __attribute__((optimize("-O0,-fno-omit-frame-pointer")))
+#elif defined(__clang__)
+#define LOAD_REGS_ATTRIBUTES [[clang::optnone]]
+#else
+#pragma warning "Unsupported compiler for per-function deoptimization"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sdk/simulation/tinst/Makefile
+++ b/sdk/simulation/tinst/Makefile
@@ -55,10 +55,6 @@ all: $(LIBSESIMU_T)
 $(LIBSESIMU_T): $(OBJS)
 	$(AR) rcs $@ $^
 
-# Explicitly disable optimization for 't_instructions.cpp',
-# since the '_SE3' function has assumptions on stack layout.
-t_instructions.o: CXXFLAGS += -O0
-
 .PHONY: clean
 clean:
 	@$(RM) $(OBJS) $(LIBSESIMU_T)

--- a/sdk/simulation/tinst/t_instructions.cpp
+++ b/sdk/simulation/tinst/t_instructions.cpp
@@ -286,6 +286,8 @@ static void _EREPORT(const sgx_target_info_t* ti, const sgx_report_data_t* rd, s
 static void
 _EEXIT(uintptr_t dest, uintptr_t xcx, uintptr_t xdx, uintptr_t xsi, uintptr_t xdi) __attribute__((section(".nipx")));
 
+// The call to load_regs assumes the existence of a frame pointer.
+LOAD_REGS_ATTRIBUTES
 static void
 _EEXIT(uintptr_t dest, uintptr_t xcx, uintptr_t xdx, uintptr_t xsi, uintptr_t xdi)
 {
@@ -323,9 +325,6 @@ _EEXIT(uintptr_t dest, uintptr_t xcx, uintptr_t xdx, uintptr_t xsi, uintptr_t xd
 
 // Master entry functions
 
-#pragma GCC push_options
-#pragma GCC optimize ("O0")
-
 uintptr_t _SE3(uintptr_t xax, uintptr_t xbx, uintptr_t xcx,
                uintptr_t xdx, uintptr_t xsi, uintptr_t xdi)
 {
@@ -350,5 +349,3 @@ uintptr_t _SE3(uintptr_t xax, uintptr_t xbx, uintptr_t xcx,
     GP();
     return (uintptr_t)-1;
 }
-
-#pragma GCC pop_options

--- a/sdk/simulation/uae_service_sim/linux/platform_service_sim.cpp
+++ b/sdk/simulation/uae_service_sim/linux/platform_service_sim.cpp
@@ -37,7 +37,9 @@
 #include <sys/types.h>
 #include <stdlib.h>
 #include <pwd.h>
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
 
 static Mutex g_pse_sim_lock;

--- a/sdk/simulation/uinst/Makefile
+++ b/sdk/simulation/uinst/Makefile
@@ -63,7 +63,7 @@ enclave_mngr.o: enclave_mngr.cpp
 # since the '_SE3' function has assumptions on stack layout.
 #
 u_instructions.o: u_instructions.cpp
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -O0 -Wno-error=cpp -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -Wno-error=cpp -c $< -o $@
 
 $(LIBSESIMU_U): u_instructions.o enclave_mngr.o $(OBJ1)
 	$(AR) rcs $@ $^

--- a/sdk/simulation/uinst/u_instructions.cpp
+++ b/sdk/simulation/uinst/u_instructions.cpp
@@ -208,7 +208,8 @@ uintptr_t _EREMOVE(const void *epc_lin_addr)
 
 // Master entry functions
 
-
+// The call to load_regs assumes the existence of a frame pointer.
+LOAD_REGS_ATTRIBUTES
 void _SE3(uintptr_t xax, uintptr_t xbx,
           uintptr_t xcx, uintptr_t xdx,
           uintptr_t xsi, uintptr_t xdi)

--- a/sdk/tlibc/gen/spinlock.c
+++ b/sdk/tlibc/gen/spinlock.c
@@ -34,7 +34,7 @@
 static inline void _mm_pause(void) __attribute__((always_inline));
 static inline int _InterlockedExchange(int volatile * dst, int val) __attribute__((always_inline));
 
-static inline void _mm_pause(void)
+static inline void _mm_pause(void)  /* definition requires -ffreestanding */
 {
     __asm __volatile(
         "pause"


### PR DESCRIPTION
The libc implementation newlib defines these symbols and causes a compiler error. Per the standard (ISO 9899:1999 reserved identifiers section), any identifier beginning with two underscores or an underscore and a capital letter is reserved for libc. The definitions are not used anywhere in the source code either.